### PR TITLE
ci: publish container

### DIFF
--- a/.github/workflows/container-ossf-slsa3-publish.yaml
+++ b/.github/workflows/container-ossf-slsa3-publish.yaml
@@ -1,0 +1,62 @@
+name: SLSA Container releaser
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+permissions: read-all
+
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+      digest: ${{ steps.build.outputs.digest }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Set up ko
+        uses: imjasonh/setup-ko@v0.8
+
+      - name: Run ko
+        id: build
+        env:
+          GIT_REF: ${{ github.ref }}
+        run: |
+          # get tag name without tags/refs/ prefix.
+          tag=$(echo ${GIT_REF} | cut -d'/' -f3)
+
+          # Build & push the image. Save the image name.
+          image_and_digest=$(ko build --tags="${tag}" .)
+
+          # Output the image name and digest so we can generate provenance.
+          image=$(echo "${image_and_digest}" | cut -d':' -f1)
+          digest=$(echo "${image_and_digest}" | cut -d'@' -f2)
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+  # This step calls the generic workflow to generate provenance.
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ${{ needs.build.outputs.image }}
+      digest: ${{ needs.build.outputs.digest }}
+      registry-username: ${{ github.actor }}
+      compile-generator: true
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for securely releasing containers using SLSA (Supply Chain Levels for Software Artifacts) level 3 compliance. The workflow includes steps for building and pushing container images, as well as generating provenance for the released containers.

New GitHub Actions workflow:

* [`.github/workflows/container-ossf-slsa3-publish.yaml`](diffhunk://#diff-9d3ec016252bc0b474522815416a0f346155486e066ab55f836109372b589e07R1-R62): Added a new workflow named "SLSA Container releaser" that triggers on workflow dispatch and release creation events. It includes jobs for building the container image and generating SLSA provenance.