### PR TITLE
feat: cache request to AWS

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"os"
+	"time"
 )
 
 const (
@@ -13,18 +14,19 @@ const (
 	EnvKeyIPAddress   = "PB_IP_ADDRESS"
 )
 
-// PBConfig holds the configuration values loaded from environment variables.
-type PBConfig struct {
-	AWSRegion   string
-	AWSProfile  string
-	AWSEndpoint string
-	Port        string
-	IPAddress   string
+// PBConfigType holds the configuration values loaded from environment variables.
+type PBConfigType struct {
+	AWSRegion     string
+	AWSProfile    string
+	AWSEndpoint   string
+	Port          string
+	IPAddress     string
+	CacheDuration time.Duration
 }
 
 // LoadPBConfig loads the configuration from environment variables.
-func LoadPBConfig() *PBConfig {
-	pbConfig := &PBConfig{
+func loadPBConfig() *PBConfigType {
+	pbConfig := &PBConfigType{
 		AWSRegion:   os.Getenv("AWS_REGION"),
 		AWSProfile:  os.Getenv("AWS_PROFILE"),
 		AWSEndpoint: os.Getenv("AWS_ENDPOINT"),
@@ -32,5 +34,20 @@ func LoadPBConfig() *PBConfig {
 		IPAddress:   os.Getenv("PB_IP_ADDRESS"),
 	}
 
+	if os.Getenv("PB_CACHE_DURATION") != "" {
+		duration, err := time.ParseDuration(os.Getenv("CACHE_DURATION"))
+		if err == nil {
+			pbConfig.CacheDuration = duration
+		}
+	} else {
+		pbConfig.CacheDuration = 60 * time.Minute
+	}
+
+	// Set UTC as the default timezone
+	time.Local = time.UTC
+
 	return pbConfig
 }
+
+// PBConfig holds the configuration values loaded from environment variables.
+var PBConfig = loadPBConfig()

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -22,7 +22,9 @@ type S3Client interface {
 
 // Client wraps the S3 client and provides additional functionality.
 type Client struct {
-	s3Client S3Client
+	s3Client              S3Client
+	CacheDuration         time.Duration
+	listObjectsCacheEntry map[string]ListObjectsCacheEntry
 }
 
 // ClientOption defines a function type for configuring the Client.
@@ -30,7 +32,7 @@ type ClientOption func(*Client) error
 
 // NewClient creates a new S3 client with the provided options.
 func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
-	pbConfig := env.LoadPBConfig()
+	pbConfig := env.PBConfig
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(pbConfig.AWSRegion),
 		config.WithSharedConfigProfile(pbConfig.AWSProfile),
@@ -51,6 +53,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 				o.UsePathStyle = true
 			}
 		}),
+		listObjectsCacheEntry: make(map[string]ListObjectsCacheEntry),
 	}
 
 	// Apply options
@@ -85,6 +88,35 @@ type BucketInfo struct {
 	CreationDate time.Time
 }
 
+// ListObjectsCacheEntry contains the data and expiry time for a listObjects cache entry.
+type ListObjectsCacheEntry struct {
+	data   *s3.ListObjectsV2Output
+	Expiry time.Time
+}
+
+// ClearListObjectsCache clears the listObjects cache for the specified bucket and prefix.
+func (c *Client) ClearListObjectsCache(ctx context.Context, bucket, prefix string) {
+	cacheKey := fmt.Sprintf("%s/%s", bucket, prefix)
+	delete(c.listObjectsCacheEntry, cacheKey)
+}
+
+// GetListObjectsCacheEntry retrieves the listObjects cache entry for the specified bucket and prefix.
+func (c *Client) GetListObjectsCacheEntry(ctx context.Context, bucket, prefix string) *ListObjectsCacheEntry {
+	cacheKey := fmt.Sprintf("%s/%s", bucket, prefix)
+	entry, _ := c.listObjectsCacheEntry[cacheKey]
+	return &entry
+}
+
+// ClearOldListObjectsCache clears the listObjects cache for entries that have expired.
+func (c *Client) ClearOldListObjectsCache(ctx context.Context) {
+	now := time.Now()
+	for key, entry := range c.listObjectsCacheEntry {
+		if entry.Expiry.Before(now) {
+			delete(c.listObjectsCacheEntry, key)
+		}
+	}
+}
+
 // ListBuckets lists all S3 buckets.
 func (c *Client) ListBuckets(ctx context.Context) ([]BucketInfo, error) {
 	result, err := c.s3Client.ListBuckets(ctx, &s3.ListBucketsInput{})
@@ -112,11 +144,20 @@ type ObjectInfo struct {
 }
 
 // ListObjects lists objects in the specified S3 bucket and prefix.
-func (c *Client) ListObjects(ctx context.Context, bucket, prefix string) ([]ObjectInfo, error) {
+func (c *Client) ListObjects(ctx context.Context, bucket, prefix string) (objectInfo []ObjectInfo, hitCache bool, err error) {
+	cacheKey := fmt.Sprintf("%s/%s", bucket, prefix)
+	now := time.Now()
+
 	// Add a trailing slash to the prefix if it doesn't already have one
 	if prefix != "" && !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}
+
+	// if the cache exists and is within the expiration date, return the cache
+	if entry, found := c.listObjectsCacheEntry[cacheKey]; found && entry.Expiry.After(now) {
+		return convertToObjectInfo(entry.data, prefix), true, nil
+	}
+
 	input := &s3.ListObjectsV2Input{
 		Bucket:    aws.String(bucket),
 		Prefix:    aws.String(prefix),
@@ -125,9 +166,19 @@ func (c *Client) ListObjects(ctx context.Context, bucket, prefix string) ([]Obje
 
 	result, err := c.s3Client.ListObjectsV2(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("ListObjectsV2 operation failed for bucket %q: %w", bucket, err)
+		return nil, false, fmt.Errorf("ListObjectsV2 operation failed for bucket %q: %w", bucket, err)
 	}
 
+	// Save to cache
+	c.listObjectsCacheEntry[cacheKey] = ListObjectsCacheEntry{
+		data:   result,
+		Expiry: now.Add(c.CacheDuration),
+	}
+
+	return convertToObjectInfo(result, prefix), false, nil
+}
+
+func convertToObjectInfo(result *s3.ListObjectsV2Output, prefix string) []ObjectInfo {
 	var objects []ObjectInfo
 	for _, commonPrefix := range result.CommonPrefixes {
 		objects = append(objects, ObjectInfo{
@@ -138,7 +189,7 @@ func (c *Client) ListObjects(ctx context.Context, bucket, prefix string) ([]Obje
 	}
 
 	for _, obj := range result.Contents {
-		 // Skip if the current prefix is the same
+		// Skip if the current prefix is the same
 		if *obj.Key == prefix {
 			continue
 		}
@@ -154,8 +205,7 @@ func (c *Client) ListObjects(ctx context.Context, bucket, prefix string) ([]Obje
 			LastModified: *obj.LastModified,
 		})
 	}
-
-	return objects, nil
+	return objects
 }
 
 // GetObject retrieves an object from the specified S3 bucket and key.

--- a/internal/s3client/client_test.go
+++ b/internal/s3client/client_test.go
@@ -157,8 +157,8 @@ func TestClient_ListObjects(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := &Client{s3Client: tt.mock}
-			result, err := client.ListObjects(context.Background(), tt.bucket, tt.prefix)
+			client := &Client{s3Client: tt.mock, listObjectsCacheEntry: make(map[string]ListObjectsCacheEntry)}
+			result, _, err := client.ListObjects(context.Background(), tt.bucket, tt.prefix)
 
 			if tt.expectedErr != "" {
 				assert.ErrorContains(t, err, tt.expectedErr)

--- a/main.go
+++ b/main.go
@@ -29,6 +29,5 @@ func main() {
 	server.SetupRoutes(e, ctx)
 
 	// Load configuration and start server
-	pbConfig := env.LoadPBConfig()
-	server.StartServer(e, pbConfig)
+	server.StartServer(e, env.PBConfig)
 }

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -22,6 +22,14 @@
 
 <body>
   <h1>{{.Bucket}}/{{.Prefix}}</h1>
+
+  <div style="height: 13px;">
+    {{if .HitCache}}
+    <p style="font-size: 13px;">⚠️ Loaded from cache. Last updated: <span class="date">{{.LastCached.Format
+        "2006-01-02T15:04:05Z" }}</span>. <a href="/{{.Bucket}}/{{.Prefix}}?refresh=true">Refresh</a>.</p>
+    {{end}}
+  </div>
+
   <ul>
     {{if .ParentPrefix}}
     <li><a href="/{{.Bucket}}/{{.ParentPrefix}}">📁 ..</a></li>
@@ -34,8 +42,8 @@
     {{if .IsDirectory}}
     <li><a href="/{{$.Bucket}}/{{.Name}}">📁 {{.ShortName}}</a></li>
     {{else}}
-    <li><a href="/download/{{$.Bucket}}/{{.Name}}" download>📄 {{.ShortName}}</a> ({{.LastModified.Format
-      "2006-01-02T15:04:05Z"}}, {{.Size}})</li>
+    <li><a href="/download/{{$.Bucket}}/{{.Name}}" download>📄 {{.ShortName}}</a> (<span
+        class="date">{{.LastModified.Format "2006-01-02T15:04:05Z"}}</span>, {{.Size}})</li>
     {{end}}
     {{end}}
   </ul>
@@ -43,7 +51,7 @@
   <br />
 
   <footer>
-    <p>
+    <p style="font-size: 13px;">
       <a href="https://github.com/korosuke613/polybuckets" target="_blank" rel="noopener noreferrer"><b>polybuckets</b>
         - Simple browser app for S3 compatible services.</a>
       <br />
@@ -51,5 +59,26 @@
     </p>
   </footer>
 </body>
+
+<script>
+  function getTimezoneOffset(offset) {
+    const offsetHours = Math.floor(Math.abs(offset / 60));
+    const offsetMins = Math.abs(offset % 60);
+    return (offset > 0 ? '-' : '+') + (offsetHours < 10 ? '0' : '') + offsetHours + ':' + (offsetMins < 10 ? '0' : '') + offsetMins;
+  }
+
+  // Convert UTC to browser local time
+  const dates = document.querySelectorAll('.date');
+  console.log(dates);
+  dates.forEach((date) => {
+    const utc = date.textContent;
+    const intlOptions = Intl.DateTimeFormat().resolvedOptions()
+    const hrs = getTimezoneOffset(new Date().getTimezoneOffset());
+    date.textContent = `${new Date(utc).toLocaleString("sv-SE", {
+      timeZone: intlOptions.timeZone
+    })} ${hrs}`;
+  });
+</script>
+
 
 </html>


### PR DESCRIPTION
This pull request introduces several changes to enhance the caching mechanism for listing objects in S3 buckets, improve configuration management, and update the server and templates to support these changes. The most important changes include adding a cache for the `ListObjects` method, updating the configuration structure, and modifying the server and templates to display cache status.

Enhancements to caching mechanism:

* [`internal/s3client/client.go`](diffhunk://#diff-0c7306fb645d59d309e7020d73e9fc84f52fdd63d14f5319a198be00f3bae9cbR26-R35): Added new fields and methods to the `Client` struct to support caching of `ListObjects` responses, including `CacheDuration`, `listObjectsCacheEntry`, and methods to manage cache entries (`ClearListObjectsCache`, `GetListObjectsCacheEntry`, `ClearOldListObjectsCache`). [[1]](diffhunk://#diff-0c7306fb645d59d309e7020d73e9fc84f52fdd63d14f5319a198be00f3bae9cbR26-R35) [[2]](diffhunk://#diff-0c7306fb645d59d309e7020d73e9fc84f52fdd63d14f5319a198be00f3bae9cbR56) [[3]](diffhunk://#diff-0c7306fb645d59d309e7020d73e9fc84f52fdd63d14f5319a198be00f3bae9cbR91-R119) [[4]](diffhunk://#diff-0c7306fb645d59d309e7020d73e9fc84f52fdd63d14f5319a198be00f3bae9cbL115-R160) [[5]](diffhunk://#diff-0c7306fb645d59d309e7020d73e9fc84f52fdd63d14f5319a198be00f3bae9cbL128-R181) [[6]](diffhunk://#diff-0c7306fb645d59d309e7020d73e9fc84f52fdd63d14f5319a198be00f3bae9cbL157-R208)

Configuration management updates:

* [`internal/env/env.go`](diffhunk://#diff-70be428cea3bbb3f5c195cace2dd721f581f9df6dcf72f26e90a905f13ea5e77L16-R53): Renamed `PBConfig` to `PBConfigType`, added a new field `CacheDuration`, and updated the loading function to include this new field.
* [`internal/s3client/client.go`](diffhunk://#diff-0c7306fb645d59d309e7020d73e9fc84f52fdd63d14f5319a198be00f3bae9cbR26-R35): Updated to use the new `PBConfig` variable instead of loading the configuration each time.

Server and template modifications:

* [`internal/server/server.go`](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L45-R65): Updated middleware to log cache hits, added logic to clear cache based on query parameters, and included cache status in the response. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L45-R65) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R79) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L121-R161) [[4]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R176-R183)
* [`templates/objects.html`](diffhunk://#diff-6e572a0c73e3c983f0497f7aed0a26dad83df141bcaefd0b6c6952f1af5903ceL37-R54): Added a section to display cache status and last updated time, and a script to convert UTC times to the browser's local time. (F3dc3d1bL29R29, [[1]](diffhunk://#diff-6e572a0c73e3c983f0497f7aed0a26dad83df141bcaefd0b6c6952f1af5903ceL37-R54) [[2]](diffhunk://#diff-6e572a0c73e3c983f0497f7aed0a26dad83df141bcaefd0b6c6952f1af5903ceR63-R83)

Testing updates:

* [`internal/s3client/client_test.go`](diffhunk://#diff-5633ebc58b32b4a98e836951345ea7dcbeec711c714be2945e62ca40ef22e291L160-R161): Updated tests to initialize the cache map and check for cache hits.